### PR TITLE
적 데이터 시트 연동

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -14752,7 +14752,7 @@ Camera:
   far clip plane: 1000
   field of view: 34
   orthographic: 1
-  orthographic size: 8.444445
+  orthographic size: 8.092592
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2

--- a/Assets/Undead Survivor/Codes/GameManager.cs
+++ b/Assets/Undead Survivor/Codes/GameManager.cs
@@ -8,7 +8,7 @@ public class GameManager : MonoBehaviour
     [Header("# Game Control")]
     public bool isLive;
     public float gameTime;
-    public float maxGameTime = 2 * 10f;
+    public float maxGameTime = 300f;
     [Header("# Player Info")]
     public int playerId;
     public float health;
@@ -29,6 +29,7 @@ public class GameManager : MonoBehaviour
     {
         instance = this;
         Application.targetFrameRate = 60;
+        StartCoroutine(GoogleSheetManager.LoadEnemyData());
     }
 
     public void GameStart(int id)

--- a/Assets/Undead Survivor/Codes/GoogleSheetManager.cs
+++ b/Assets/Undead Survivor/Codes/GoogleSheetManager.cs
@@ -1,0 +1,38 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.Networking;
+
+public static class GoogleSheetManager
+{
+    const string enemyDataURL = "https://docs.google.com/spreadsheets/d/1hkeJTxClO7M_wVIFX7R5rZ8OjTGmH9WhZzm6r_L7EZM/export?format=tsv";
+
+    [SerializeField]
+    public static SpawnData[] spawnData = null;
+    
+    public static IEnumerator LoadEnemyData()
+    {
+        UnityWebRequest www = UnityWebRequest.Get(enemyDataURL);
+        yield return www.SendWebRequest();
+
+        string enemyData = www.downloadHandler.text;
+        Debug.Log(enemyData);
+        ParseEnemyData(enemyData);
+    }
+
+    public static void ParseEnemyData(string data)
+    {
+        string[] lines = data.Split('\n');
+        spawnData = new SpawnData[lines.Length-1];
+        for (int i = 1; i < lines.Length; i++) {
+            string[] fields = lines[i].Split('\t');
+            SpawnData enemy = new SpawnData()
+            {
+                spawnTime = float.Parse(fields[1]),
+                spriteType = int.Parse(fields[0]),
+                health = int.Parse(fields[3]),
+                speed = float.Parse(fields[4]),
+            };
+            spawnData[i-1] = enemy;
+        }
+    }
+}

--- a/Assets/Undead Survivor/Codes/GoogleSheetManager.cs.meta
+++ b/Assets/Undead Survivor/Codes/GoogleSheetManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6b5e9b71bb47af7469bc892b9334b892
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Undead Survivor/Codes/Spawner.cs
+++ b/Assets/Undead Survivor/Codes/Spawner.cs
@@ -12,6 +12,7 @@ public class Spawner : MonoBehaviour
     void Awake()
     {
         spawnPoint = GetComponentsInChildren<Transform>();
+        spawnData = GoogleSheetManager.spawnData;
         levelTime = GameManager.instance.maxGameTime / spawnData.Length;
     }
 

--- a/Assets/Undead Survivor/Prefabs/Enemy.prefab
+++ b/Assets/Undead Survivor/Prefabs/Enemy.prefab
@@ -166,6 +166,8 @@ MonoBehaviour:
   animCon:
   - {fileID: 22100000, guid: 050556270436d4f4288557291a1a99c0, type: 2}
   - {fileID: 22100000, guid: 12cfc8b2360c2fc4499d4f6f6607671a, type: 2}
+  - {fileID: 22100000, guid: 8d1d920724ffb8a409ce0e458dc4b7a9, type: 2}
+  - {fileID: 22100000, guid: 25f7a818644b68042bb0c0c2a28d1550, type: 2}
   target: {fileID: 0}
 --- !u!114 &6868107195469920027
 MonoBehaviour:


### PR DESCRIPTION
1.0 -> 1.1 버전 업

- 적 2종 추가
- 적 데이터 시트 연동을 Static Class로 구현
- 이제 이 클래스의 정적 필드 spawnData에 접근하면 모든 적의 데이터를 알아낼 수 있음